### PR TITLE
Correção na docstring e docs do módulo fordev.validators

### DIFF
--- a/docs/source/fordev/validators.rst
+++ b/docs/source/fordev/validators.rst
@@ -75,6 +75,30 @@ Docs de todas funções
                 >>> is_valid_credit_card(flag=3)  # Visa Electron
 
 .. autofunction:: fordev.validators.is_valid_bank_account
+
+    :Bandeiras suportadas:
+
+        ``1`` = **Banco do Brasil**
+
+        ``2`` = **Bradesco**
+
+        ``3`` = **Citibank**
+
+        ``4`` = **Itaú**
+
+        ``5`` = **Santander**
+
+        .. note::
+
+            O valor númerico que representa a bandeira do banco deve ser passada para o parâmetro ``bank``.
+
+            **Exemplo:**
+
+            .. code-block:: python
+
+                >>> from fordev.validators import is_valid_bank_account
+                >>> is_valid_bank_account(bank=4)  # Itaú
+
 .. autofunction:: fordev.validators.is_valid_certificate
 .. autofunction:: fordev.validators.is_valid_cnh
 .. autofunction:: fordev.validators.is_valid_cnpj

--- a/docs/source/fordev/validators.rst
+++ b/docs/source/fordev/validators.rst
@@ -36,6 +36,44 @@ Docs de todas funções
 ---------------------
 
 .. autofunction:: fordev.validators.is_valid_credit_card
+
+    :Bandeiras suportadas:
+
+        ``1`` = **MasterCard**
+
+        ``2`` = **Visa 16 Dígitos**
+
+        ``3`` = **Visa Electron**
+
+        ``4`` = **American Express**
+
+        ``5`` = **Diners Club**
+
+        ``6`` = **Discover**
+
+        ``7`` = **enRoute**
+
+        ``8`` = **JCB**
+
+        ``9`` = **Maestro**
+
+        ``10`` = **Solo**
+
+        ``11`` = **Switch**
+
+        ``12`` = **Laser**
+
+        .. note::
+
+            O valor númerico que representa a bandeira do cartão de crédito deve ser passada para o parâmetro ``flag``.
+
+            **Exemplo:**
+
+            .. code-block:: python
+
+                >>> from fordev.validators import is_valid_credit_card
+                >>> is_valid_credit_card(flag=3)  # Visa Electron
+
 .. autofunction:: fordev.validators.is_valid_bank_account
 .. autofunction:: fordev.validators.is_valid_certificate
 .. autofunction:: fordev.validators.is_valid_cnh

--- a/fordev/__about__.py
+++ b/fordev/__about__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Metadados do projeto."""
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 __author__ = 'Matheus Felipe'
 __email__ = 'matheusfelipeog@protonmail.com'
 __author_github__ = 'https://github.com/matheusfelipeog'

--- a/fordev/validators.py
+++ b/fordev/validators.py
@@ -154,18 +154,15 @@ def is_valid_bank_account(bank: int, agency: str, account: str, data_only: bool=
     ----------
     bank
         A bandeira do banco da conta bancária que deseja validar os dados.
-        Opções:
-            1 = Banco do Brasil
-            2 = Bradesco
-            3 = Citibank
-            4 = Itaú
-            5 = Santander
+        
+        Consulte a doc para verificar as opções suportadas:
+        https://fordev.rtfd.io/pt_BR/latest/fordev/generators.html
     
     agency
-        O código da agência bancária para verificação..
+        O código da agência bancária para verificação.
 
     account
-        O código da conta bancária para verificação..
+        O código da conta bancária para verificação.
    """
 
     # Check if bank code is invalid. If true, raise exception.

--- a/fordev/validators.py
+++ b/fordev/validators.py
@@ -115,19 +115,9 @@ def is_valid_credit_card(flag: int, credit_card_code: str, data_only: bool=True)
     ----------
     flag
         A bandeira do cartão de crédito que deseja validar o código.
-        Opções:
-            1 = MasterCard
-            2 = Visa 16 Dígitos
-            3 = Visa Electron
-            4 = American Express
-            5 = Diners Club
-            6 = Discover
-            7 = enRoute
-            8 = JCB
-            9 = Maestro
-            10 = Solo
-            11 = Switch
-            12 = Laser
+        
+        Consulte a doc para verificar as opções suportadas:
+        https://fordev.rtfd.io/pt_BR/latest/fordev/generators.html
 
     credit_card_code
         O código do cartão de crédito para verificação.


### PR DESCRIPTION
# Mudanças

- Remoção da seção de opções de valores de um parâmetro das docstrings, estava quebrando o layout da documentação.
- Transferido a seção de opções de valores para a documentação oficial.